### PR TITLE
Update Markdown File Detection in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
+*.md linguist-documentation=false
 *.md linguist-detectable


### PR DESCRIPTION
# Pull Request

## TL;DR

Updated .gitattributes to ensure Markdown files are not classified as documentation.

## What changed?

- Modified .gitattributes file:
  - Added a new line to prevent Markdown files from being classified as documentation
  - Retained existing configuration for Markdown files to be detectable