### PR TITLE
Pin GitHub Action Versions

### DIFF
--- a/.github/workflows/check-everything.yml
+++ b/.github/workflows/check-everything.yml
@@ -5,7 +5,6 @@ on:
     branches: [main]
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-  merge_group:
 
 permissions:
   contents: read
@@ -18,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
       - name: Lint Code Base
@@ -35,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -3,7 +3,6 @@ name: Dependency Review
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-  merge_group:
 
 permissions:
   contents: read
@@ -14,6 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
       - name: Dependency Review
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@v4.4.0

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,15 +20,15 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
 
       - name: Build with Jekyll
-        uses: actions/jekyll-build-pages@v1
+        uses: actions/jekyll-build-pages@v1.0.13
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v3.0.1
 
       - name: Deploy to GitHub Pages
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v4.0.5


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes updates to GitHub Actions workflows to ensure compatibility and improve functionality. The most important changes include updating action versions and modifying workflow triggers.

### Workflow updates:

* [`.github/workflows/check-everything.yml`](diffhunk://#diff-4dd84dd6da9ad3de39ce8fb6ebb289ee7a656956984dbe3ff166848b6602a171L8): Updated `actions/checkout` to version `v4.2.2` in both the `Checkout` and `Checkout Repository` steps. Removed the `merge_group` trigger. [[1]](diffhunk://#diff-4dd84dd6da9ad3de39ce8fb6ebb289ee7a656956984dbe3ff166848b6602a171L8) [[2]](diffhunk://#diff-4dd84dd6da9ad3de39ce8fb6ebb289ee7a656956984dbe3ff166848b6602a171L21-R20) [[3]](diffhunk://#diff-4dd84dd6da9ad3de39ce8fb6ebb289ee7a656956984dbe3ff166848b6602a171L38-R37)
* [`.github/workflows/dependency-review.yml`](diffhunk://#diff-7cdd3ccec44c8ba176bdc3b9ef54c3f56aa210a1a4e2bb5f79d87b1e50314a18L6): Updated `actions/checkout` to version `v4.2.2` and `actions/dependency-review-action` to version `v4.4.0`. Removed the `merge_group` trigger. [[1]](diffhunk://#diff-7cdd3ccec44c8ba176bdc3b9ef54c3f56aa210a1a4e2bb5f79d87b1e50314a18L6) [[2]](diffhunk://#diff-7cdd3ccec44c8ba176bdc3b9ef54c3f56aa210a1a4e2bb5f79d87b1e50314a18L17-R18)
* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L23-R34): Updated `actions/checkout` to version `v4.2.2`, `actions/jekyll-build-pages` to version `v1.0.13`, `actions/upload-pages-artifact` to version `v3.0.1`, and `actions/deploy-pages` to version `v4.0.5`.