### PR TITLE
Refactor GitHub Workflows Triggers

### DIFF
--- a/.github/workflows/check-everything.yml
+++ b/.github/workflows/check-everything.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize]
 
 permissions:
   contents: read

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -2,7 +2,7 @@ name: Dependency Review
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize]
 
 permissions:
   contents: read
@@ -14,5 +14,6 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4.2.2
+
       - name: Dependency Review
         uses: actions/dependency-review-action@v4.4.0


### PR DESCRIPTION
# Pull Request

## Description

This pull request makes changes to the GitHub Actions workflows to streamline the types of pull request events that trigger actions and to update the dependency review action.

Changes to GitHub Actions workflows:

* [`.github/workflows/check-everything.yml`](diffhunk://#diff-4dd84dd6da9ad3de39ce8fb6ebb289ee7a656956984dbe3ff166848b6602a171L7-R7): Removed `reopened` and `ready_for_review` events from the list of pull request types that trigger the workflow.
* [`.github/workflows/dependency-review.yml`](diffhunk://#diff-7cdd3ccec44c8ba176bdc3b9ef54c3f56aa210a1a4e2bb5f79d87b1e50314a18L5-R5): Removed `reopened` and `ready_for_review` events from the list of pull request types that trigger the workflow.
* [`.github/workflows/dependency-review.yml`](diffhunk://#diff-7cdd3ccec44c8ba176bdc3b9ef54c3f56aa210a1a4e2bb5f79d87b1e50314a18R17): Added a blank line between steps in the `jobs` section for better readability.
