### PR TITLE
Add Actionlint Job

### DIFF
--- a/.github/super-linter-configs/.yaml-lint.yml
+++ b/.github/super-linter-configs/.yaml-lint.yml
@@ -4,3 +4,4 @@ rules:
   document-start: disable
   truthy: disable
   line-length: disable
+  comments: disable

--- a/.github/workflows/check-everything.yml
+++ b/.github/workflows/check-everything.yml
@@ -46,3 +46,18 @@ jobs:
           reporter: github-pr-review
           fail_on_error: true
           filter_mode: nofilter
+
+  run-actionlint:
+    name: Check GitHub Actions with actionlint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Install actionlint
+        id: get_actionlint
+        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+      - name: Check workflow files
+        run: ${{ steps.get_actionlint.outputs.executable }} -color # zizmor: ignore[template-injection]


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new job to the GitHub Actions workflow and disables comments in the YAML linting configuration. The most important changes include adding a job to check GitHub Actions with `actionlint` and updating the YAML linting rules.

Enhancements to GitHub Actions workflow:

* [`.github/workflows/check-everything.yml`](diffhunk://#diff-4dd84dd6da9ad3de39ce8fb6ebb289ee7a656956984dbe3ff166848b6602a171R49-R63): Added a new job `run-actionlint` to check GitHub Actions with `actionlint`, including steps to checkout the repository, install `actionlint`, and run the checks.

Updates to YAML linting configuration:

* [`.github/super-linter-configs/.yaml-lint.yml`](diffhunk://#diff-cdea8bea457c52a8c0651465a847dcbc52c6abd1fb370c531b89a3214efad8bbR7): Disabled comments in the YAML linting rules.