### PR TITLE
Add Zizmor Job

### DIFF
--- a/.github/workflows/check-everything.yml
+++ b/.github/workflows/check-everything.yml
@@ -20,8 +20,9 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Lint Code Base
-        uses: super-linter/super-linter/slim@v7.2.0
+        uses: super-linter/super-linter/slim@v7.2.1
         env:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: main
@@ -37,7 +38,7 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
-
+          persist-credentials: false
       - name: Check Markdown links
         uses: UmbrellaDocs/action-linkspector@v1.2.4
         with:

--- a/.github/workflows/check-everything.yml
+++ b/.github/workflows/check-everything.yml
@@ -61,3 +61,28 @@ jobs:
         run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
       - name: Check workflow files
         run: ${{ steps.get_actionlint.outputs.executable }} -color # zizmor: ignore[template-injection]
+
+  run-zizmor:
+    name: Check GitHub Actions with zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v4.2.0
+        with:
+          version: "latest"
+      - name: Run zizmor 🌈
+        run: uvx zizmor --format sarif . > results.sarif
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v3.27.9
+        with:
+          sarif_file: results.sarif
+          category: zizmor

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4.2.2
-
+        with:
+          fetch-depth: 0
+          persist-credentials: false
       - name: Dependency Review
         uses: actions/dependency-review-action@v4.5.0

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,19 +16,16 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: github-pages
-
     timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
-
+          persist-credentials: false
       - name: Build with Jekyll
         uses: actions/jekyll-build-pages@v1.0.13
-
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3.0.1
-
       - name: Deploy to GitHub Pages
         uses: actions/deploy-pages@v4.0.5


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes several updates to the GitHub Actions workflows to enhance security and add new checks. The most important changes are the addition of the `run-zizmor` job, updates to the `super-linter` version, and the addition of the `persist-credentials` parameter.

New job addition:

* [`.github/workflows/check-everything.yml`](diffhunk://#diff-4dd84dd6da9ad3de39ce8fb6ebb289ee7a656956984dbe3ff166848b6602a171R65-R89): Added a new job `run-zizmor` to check GitHub Actions with zizmor, including steps to install `uv`, run `zizmor`, and upload the SARIF file.

Security enhancements:

* [`.github/workflows/check-everything.yml`](diffhunk://#diff-4dd84dd6da9ad3de39ce8fb6ebb289ee7a656956984dbe3ff166848b6602a171R23-R25): Added `persist-credentials: false` to the `actions/checkout` steps to enhance security. [[1]](diffhunk://#diff-4dd84dd6da9ad3de39ce8fb6ebb289ee7a656956984dbe3ff166848b6602a171R23-R25) [[2]](diffhunk://#diff-4dd84dd6da9ad3de39ce8fb6ebb289ee7a656956984dbe3ff166848b6602a171L40-R41)
* [`.github/workflows/dependency-review.yml`](diffhunk://#diff-7cdd3ccec44c8ba176bdc3b9ef54c3f56aa210a1a4e2bb5f79d87b1e50314a18L17-R19): Added `persist-credentials: false` to the `actions/checkout` step.
* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L19-L32): Added `persist-credentials: false` to the `actions/checkout` step.

Version updates:

* [`.github/workflows/check-everything.yml`](diffhunk://#diff-4dd84dd6da9ad3de39ce8fb6ebb289ee7a656956984dbe3ff166848b6602a171R23-R25): Updated `super-linter` from version `v7.2.0` to `v7.2.1`.
