### PR TITLE
Remove Actionlint Job

### DIFF
--- a/.github/super-linter-configs/.yaml-lint.yml
+++ b/.github/super-linter-configs/.yaml-lint.yml
@@ -4,4 +4,5 @@ rules:
   document-start: disable
   truthy: disable
   line-length: disable
-  comments: disable
+  comments:
+    min-spaces-from-content: 1

--- a/.github/workflows/check-everything.yml
+++ b/.github/workflows/check-everything.yml
@@ -49,21 +49,6 @@ jobs:
           fail_on_error: true
           filter_mode: nofilter
 
-  run-actionlint:
-    name: Check GitHub Actions with actionlint
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Install actionlint
-        id: get_actionlint
-        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
-      - name: Check workflow files
-        run: ${{ steps.get_actionlint.outputs.executable }} -color # zizmor: ignore[template-injection]
-
   run-zizmor:
     name: Check GitHub Actions with zizmor
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes changes to the YAML linting rules and the GitHub Actions workflow configuration. The most important changes involve updating the YAML linting rules for comments and removing the `run-actionlint` job from the workflow.

Updates to YAML linting rules:

* [`.github/super-linter-configs/.yaml-lint.yml`](diffhunk://#diff-cdea8bea457c52a8c0651465a847dcbc52c6abd1fb370c531b89a3214efad8bbL7-R8): Modified the `comments` rule to require at least one space from content.

Changes to GitHub Actions workflow:

* [`.github/workflows/check-everything.yml`](diffhunk://#diff-4dd84dd6da9ad3de39ce8fb6ebb289ee7a656956984dbe3ff166848b6602a171L52-L66): Removed the `run-actionlint` job, which previously checked GitHub Actions workflows with `actionlint`.
