### PR TITLE
Set markdown-link-checker job runner to ubuntu-22.04

### DIFF
--- a/.github/workflows/check-everything.yml
+++ b/.github/workflows/check-everything.yml
@@ -33,7 +33,7 @@ jobs:
 
   check-markdown-links:
     name: Check Markdown links
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4.2.2


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes an update to the GitHub Actions workflow configuration. The most important change is the update of the runner version for the "Check Markdown links" job.

Workflow configuration update:

* [`.github/workflows/check-everything.yml`](diffhunk://#diff-4dd84dd6da9ad3de39ce8fb6ebb289ee7a656956984dbe3ff166848b6602a171L36-R36): Updated the runner version for the "Check Markdown links" job from `ubuntu-latest` to `ubuntu-22.04`.