### PR TITLE
Disable Deployment Concurrency

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   deploy-github-pages:
     name: Deploy to GitHub Pages


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a change to the GitHub Actions workflow configuration file to improve the deployment process.

Improvements to deployment process:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R10-R13): Added `concurrency` settings to ensure that only one deployment job runs at a time and cancels any in-progress jobs if a new one is triggered.
