### PR TITLE
Check Justfile Format

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -51,6 +51,20 @@ jobs:
           fail_on_error: true
           filter_mode: nofilter
 
+  check-justfile-format:
+    name: Check Justfile Format
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Set up Just
+        uses: extractions/setup-just@v2
+      - name: Check Justfile Format
+        run: just format-check
+
   run-zizmor:
     name: Check GitHub Actions with zizmor
     runs-on: ubuntu-latest
@@ -63,7 +77,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v5.2.2
+        uses: astral-sh/setup-uv@v5.3.0
         with:
           version: "latest"
       - name: Run zizmor 🌈
@@ -71,7 +85,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3.28.8
+        uses: github/codeql-action/upload-sarif@v3.28.10
         with:
           sarif_file: results.sarif
           category: zizmor
@@ -88,10 +102,10 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3.28.8
+        uses: github/codeql-action/init@v3.28.10
         with:
           languages: actions
           queries: security-and-quality
           config-file: .github/other-configs/codeql-config.yml
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3.28.8
+        uses: github/codeql-action/analyze@v3.28.10


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes updates to the `.github/workflows/code-checks.yml` file to add a new job for checking the Justfile format and to update the versions of several GitHub Actions.

New job addition:

* Added a new job `check-justfile-format` to the GitHub Actions workflow to ensure the Justfile format is correct. This job includes steps for checking out the repository, setting up Just, and running the format check.

Version updates:

* Updated the `astral-sh/setup-uv` action from version `v5.2.2` to `v5.3.0` for installing the latest version of uv.
* Updated the `github/codeql-action/upload-sarif` action from version `v3.28.8` to `v3.28.10` for uploading SARIF files.
* Updated the `github/codeql-action/init` action from version `v3.28.8` to `v3.28.10` for initializing CodeQL.
* Updated the `github/codeql-action/analyze` action from version `v3.28.8` to `v3.28.10` for performing CodeQL analysis.