### PR TITLE
Add Lefthook Validate Job

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -89,6 +89,22 @@ jobs:
           sarif_file: results.sarif
           category: zizmor
 
+  lefthook-validate:
+    name: Lefthook Validate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v5.3.1
+        with:
+          version: "latest"
+      - name: Run Lefthook Validate
+        run: uvx lefthook validate
+
   run-codeql-analysis:
     name: CodeQL Analysis
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new job for Lefthook validation in the GitHub Actions workflow file. The most important change is the addition of the `lefthook-validate` job which includes steps to checkout the repository, install the latest version of `uv`, and run Lefthook validation.

Key changes:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R92-R107): Added a new job `lefthook-validate` to the workflow, which includes steps for checking out the repository, installing `uv`, and running Lefthook validation.