### PR TITLE
Fix Zizmor SARIF Command

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -78,11 +78,11 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1
-        with:
-          version: "latest"
+        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
+      - name: Set up Just
+        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
       - name: Run zizmor 🌈
-        run: uvx zizmor --format sarif . > results.sarif
+        run: just zizmor-check-sarif
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload SARIF file

--- a/Justfile
+++ b/Justfile
@@ -44,7 +44,11 @@ lefthook-validate:
 
 # Run zizmor checking
 zizmor-check:
-    zizmor . --pedantic --persona=pedantic
+    uvx zizmor . --persona=pedantic
+
+# Run zizmor checking with sarif output
+zizmor-check-sarif:
+    uvx zizmor . --persona=pedantic --format sarif > results.sarif
 
 # ------------------------------------------------------------------------------
 # Pinact


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the workflow configuration and the `Justfile` to streamline the use of tools and improve maintainability. The most important changes include upgrading the `setup-uv` action, adding a new setup for `Just`, and modifying commands for running `zizmor` checks.

### Workflow updates:
* Updated `.github/workflows/code-checks.yml` to use `setup-uv@v6.0.1` instead of `v5.4.1`, ensuring compatibility with the latest version.
* Added a new step in `.github/workflows/code-checks.yml` to set up `Just` using `extractions/setup-just@v3`.
* Replaced the `uvx zizmor` command with a `just` command (`just zizmor-check-sarif`) for running `zizmor` checks in SARIF format.

### `Justfile` updates:
* Added a new `zizmor-check-sarif` recipe to the `Justfile` for running `zizmor` checks with SARIF output.
* Updated the `zizmor-check` recipe in the `Justfile` to use `uvx` for consistency with the new workflow.