### PR TITLE
Swap SuperLinter to Full Version

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Lint Code Base
-        uses: super-linter/super-linter/slim@4e8a7c2bf106c4c766c816b35ec612638dc9b6b2 # v7.3.0
+        uses: super-linter/super-linter@4e8a7c2bf106c4c766c816b35ec612638dc9b6b2 # v7.3.0
         env:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: main


### PR DESCRIPTION
# Pull Request

## Description

This pull request makes a small change to the `.github/workflows/code-checks.yml` file to update the GitHub Action used for linting the codebase.

* Updated the `Lint Code Base` step to use `super-linter/super-linter` instead of `super-linter/super-linter/slim` in the GitHub Actions workflow. This change simplifies the action reference while keeping the same version (`v7.3.0`). (`[.github/workflows/code-checks.ymlL27-R27](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L27-R27)`)