### PR TITLE
Migrate to Reusable CodeQL Analysis

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -42,21 +42,14 @@ jobs:
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}
 
-  run-codeql-analysis:
+  codeql-checks:
     name: CodeQL Analysis
-    runs-on: ubuntu-latest
     permissions:
+      contents: read
       security-events: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@60168efe1c415ce0f5521ea06d5c2062adbeed1b # v3.28.17
-        with:
-          languages: actions
-          queries: security-and-quality
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@60168efe1c415ce0f5521ea06d5c2062adbeed1b # v3.28.17
+    strategy:
+      matrix:
+        language: [actions]
+    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@72df376b6d16d40834a212c93d2869295e4d9b39 # v2025.05.24.02
+    with:
+      language: ${{ matrix.language }}


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the CodeQL analysis workflow in `.github/workflows/code-checks.yml` to streamline its configuration and improve maintainability by leveraging a reusable workflow. The most important changes include renaming the job, adjusting permissions, and replacing inline steps with a reusable workflow reference.

### Workflow configuration updates:

* Renamed the `run-codeql-analysis` job to `codeql-checks` for better clarity and alignment with its purpose.
* Updated permissions to explicitly set `contents: read` and `security-events: write` for enhanced security and clarity.
* Replaced inline CodeQL setup and analysis steps with a reusable workflow reference (`JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@72df376b6d16d40834a212c93d2869295e4d9b39`), simplifying the workflow and centralizing its maintenance.
* Introduced a matrix strategy for the `language` parameter, enabling better scalability and flexibility in the analysis process.