### PR TITLE
Set Zizmor persona to auditor

### DIFF
--- a/.github/workflows/clean-caches.yml
+++ b/.github/workflows/clean-caches.yml
@@ -12,6 +12,6 @@ jobs:
     name: Clean Caches
     permissions:
       contents: read
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-clean-caches.yml@8f2eda10bf25fcde227b8912532306822183645e # v2025.06.12.02
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-clean-caches.yml@9aeb375514588fbc71eae2823e3216d43d300501 # v2025.06.16.01
     secrets:
       workflow_github_token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -39,7 +39,7 @@ jobs:
       actions: read
       pull-requests: write
       security-events: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@8f2eda10bf25fcde227b8912532306822183645e # v2025.06.12.02
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@9aeb375514588fbc71eae2823e3216d43d300501 # v2025.06.16.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -51,6 +51,6 @@ jobs:
     strategy:
       matrix:
         language: [actions]
-    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@8f2eda10bf25fcde227b8912532306822183645e # v2025.06.12.02
+    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@9aeb375514588fbc71eae2823e3216d43d300501 # v2025.06.16.01
     with:
       language: ${{ matrix.language }}

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -12,6 +12,6 @@ jobs:
     name: Common Pull Request Tasks
     permissions:
       pull-requests: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@8f2eda10bf25fcde227b8912532306822183645e # v2025.06.12.02
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@9aeb375514588fbc71eae2823e3216d43d300501 # v2025.06.16.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -15,6 +15,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml@8f2eda10bf25fcde227b8912532306822183645e # v2025.06.12.02
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml@9aeb375514588fbc71eae2823e3216d43d300501 # v2025.06.16.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the reusable workflow versions across several GitHub Actions workflow files to ensure the latest version (`v2025.06.16.01`) is used. These updates maintain consistency and incorporate any improvements or fixes available in the newer version.

Updated reusable workflow versions:

* [`.github/workflows/clean-caches.yml`](diffhunk://#diff-d0394e4336a74cdfc1d4cff05d056b893ac7ff922eacf4448e104a754f386b8dL15-R15): Updated the reusable workflow reference from `v2025.06.12.02` to `v2025.06.16.01`.
* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L42-R42): Updated references for `common-code-checks.yml` and `codeql-analysis.yml` workflows from `v2025.06.12.02` to `v2025.06.16.01`. [[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L42-R42) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L54-R54)
* [`.github/workflows/pull-request-tasks.yml`](diffhunk://#diff-ba6496a5b7a58ac3681ed047691dc32281cc7d548fff1d41201babbd65ad45cfL15-R15): Updated the reusable workflow reference from `v2025.06.12.02` to `v2025.06.16.01`.
* [`.github/workflows/sync-labels.yml`](diffhunk://#diff-a877ed9f27d115d95934fd904f2475dcec6ce4125da686dd5b3c75a696fff1c6L18-R18): Updated the reusable workflow reference from `v2025.06.12.02` to `v2025.06.16.01`.