### PR TITLE
Set Zizmor Persona to Auditor

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -44,7 +44,7 @@ lefthook-validate:
 
 # Run zizmor checking
 zizmor-check:
-    uvx zizmor . --persona=pedantic
+    uvx zizmor . --persona=auditor
 
 # ------------------------------------------------------------------------------
 # Pinact


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a minor update to the `Justfile`. The change updates the `lefthook-validate:` script to use the `auditor` persona instead of `pedantic` for the `zizmor-check` command.