### PR TITLE
Update License to Licence

### DIFF
--- a/.github/other-configurations/labeller.yml
+++ b/.github/other-configurations/labeller.yml
@@ -25,7 +25,7 @@ markdown:
               [
                 "docs/*.md",
                 "*.md",
-                "LICENSE",
+                "LICENCE",
                 ".github/pull_request_template.md",
               ]
 python:


### PR DESCRIPTION
# Pull Request

## Description

This pull request makes a small update to the documentation label configuration. The change corrects the filename for the license file in the `markdown:` section of the `.github/other-configurations/labeller.yml` file. 

* Changed the label configuration to use `LICENCE` instead of `LICENSE` in the list of markdown-related files.