### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,13 +24,13 @@ jobs:
       id-token: write
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
           persist-credentials: false
       - name: Build with Jekyll
         uses: actions/jekyll-build-pages@44a6e6beabd48582f863aeeb6cb2151cc1716697 # v1.0.13
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
       - name: Deploy to GitHub Pages
         uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the GitHub Actions workflow configuration to use the latest major versions of key actions for improved stability and support.

Dependency updates:

* Updated `actions/checkout` from version `v4.2.2` to `v5.0.0` in `.github/workflows/deploy.yml`, ensuring compatibility with the latest features and bug fixes.
* Updated `actions/upload-pages-artifact` from version `v3.0.1` to `v4.0.0` in `.github/workflows/deploy.yml` for improved artifact handling and reliability.